### PR TITLE
feature(Previews): Crop page-2 factsheet thumbnails to chart area for consistent aspect ratio

### DIFF
--- a/.github/workflows/generate-factsheets.yml
+++ b/.github/workflows/generate-factsheets.yml
@@ -29,7 +29,11 @@ jobs:
       UNRAVEL_API_KEY: ${{ secrets.UNRAVEL_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v6
+      # Pinned to v5: actions/checkout@v6 breaks the create-pull-request
+      # step below with `remote: Duplicate header: "Authorization"` (HTTP
+      # 400). Revert to @v6 once the upstream incompatibility is fixed.
+      # https://github.com/peter-evans/create-pull-request/issues/4272
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/generate-notebooks.yml
+++ b/.github/workflows/generate-notebooks.yml
@@ -28,7 +28,11 @@ jobs:
       NOTEBOOK_JOBS: '4'
 
     steps:
-      - uses: actions/checkout@v6
+      # Pinned to v5: actions/checkout@v6 breaks the create-pull-request
+      # step below with `remote: Duplicate header: "Authorization"` (HTTP
+      # 400). Revert to @v6 once the upstream incompatibility is fixed.
+      # https://github.com/peter-evans/create-pull-request/issues/4272
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:

--- a/scripts/factsheet/page_two.py
+++ b/scripts/factsheet/page_two.py
@@ -19,6 +19,7 @@ import matplotlib.ticker as mtick
 import numpy as np
 import pandas as pd
 from matplotlib.gridspec import GridSpec
+from matplotlib.transforms import Bbox
 
 from scripts.factors_catalog import BOOKING_URL, Factor
 from scripts.factsheet import metrics, theme
@@ -563,3 +564,41 @@ def render_page_two(
 
     _draw_about_and_notice(fig, factor)
     return fig
+
+
+def charts_bbox(fig: plt.Figure) -> Bbox | None:
+    """Tight bounding box (in inches) around just the analysis charts.
+
+    The page-2 figure doubles as the web resource-card thumbnail, but the
+    full A4 page — header, intro copy and the long legal notice — renders
+    far taller than the notebook-derived cards beside it on the site.
+    Cropping to the GridSpec subplots (titles and tick labels included,
+    header/footer excluded) brings it to a comparable aspect ratio.
+
+    Returns None when the page has no chart subplots (e.g. the
+    unavailable-analysis fallback), so callers can fall back to the full
+    figure. The logo is added via ``fig.add_axes`` and has no
+    subplotspec, so it is naturally excluded.
+    """
+    chart_axes = [
+        ax for ax in fig.get_axes() if ax.get_subplotspec() is not None
+    ]
+    if not chart_axes:
+        return None
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    boxes = [
+        bb
+        for ax in chart_axes
+        if (bb := ax.get_tightbbox(renderer)) is not None
+    ]
+    if not boxes:
+        return None
+    bb_in = Bbox.union(boxes).transformed(fig.dpi_scale_trans.inverted())
+    pad = 0.12  # inches — small breathing room around the chart cluster
+    return Bbox.from_extents(
+        bb_in.x0 - pad,
+        bb_in.y0 - pad,
+        bb_in.x1 + pad,
+        bb_in.y1 + pad,
+    )

--- a/scripts/generate_factsheets.py
+++ b/scripts/generate_factsheets.py
@@ -38,7 +38,7 @@ from scripts.factors_catalog import Factor  # noqa: E402
 from scripts.factsheet import metrics  # noqa: E402
 from scripts.factsheet.al_utils import clean_factor_data  # noqa: E402
 from scripts.factsheet.page_one import render_page_one  # noqa: E402
-from scripts.factsheet.page_two import render_page_two  # noqa: E402
+from scripts.factsheet.page_two import charts_bbox, render_page_two  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FACTSHEETS_DIR = REPO_ROOT / "factsheets"
@@ -117,8 +117,15 @@ def render_factsheet(factor: Factor, api_key: str) -> Path:
         page2 = render_page_two(factor, factor_data, prices)
         pdf.savefig(page2)
         # Page 2 (the AlphaLens analysis) doubles as the web resource-card
-        # thumbnail — always factor-specific.
-        page2.savefig(PREVIEWS_DIR / f"{factor.id}.png", dpi=150)
+        # thumbnail — always factor-specific. Crop it to just the chart
+        # cluster so its aspect ratio matches the notebook-derived cards
+        # beside it; the PDF keeps the full page.
+        crop = charts_bbox(page2)
+        page2.savefig(
+            PREVIEWS_DIR / f"{factor.id}.png",
+            dpi=150,
+            bbox_inches=crop if crop is not None else None,
+        )
         plt.close(page2)
 
     print(f"  ✓ wrote {out.relative_to(REPO_ROOT)}")


### PR DESCRIPTION
## Summary
This change improves the visual consistency of factsheet thumbnails used as web resource cards by cropping them to just the analysis charts, excluding the header, intro copy, and legal notice that make the full A4 page too tall.

## Key Changes
- Added `charts_bbox()` function to `page_two.py` that calculates a tight bounding box around only the GridSpec chart subplots
  - Returns `None` for fallback cases (e.g., unavailable-analysis pages with no charts)
  - Includes small padding (0.12 inches) around the chart cluster for breathing room
  - Naturally excludes the logo which is added via `fig.add_axes` without a subplotspec
- Updated `generate_factsheets.py` to use the new bounding box when saving page-2 PNG thumbnails
  - The PDF output remains unchanged (full page)
  - PNG thumbnails are now cropped to match the aspect ratio of notebook-derived cards on the website

## Implementation Details
- The bounding box calculation uses matplotlib's renderer to get tight bounding boxes for each chart axis, then unions them together
- Conversion from display coordinates to inches uses `fig.dpi_scale_trans.inverted()`
- Gracefully handles edge cases where no chart axes exist or tight bounding boxes cannot be computed

https://claude.ai/code/session_01RWM6eBoXEBY9rGQFLj4XLZ