### PR TITLE
feature(CI): Trigger factsheet generation on main branch pushes

### DIFF
--- a/.github/workflows/generate-factsheets.yml
+++ b/.github/workflows/generate-factsheets.yml
@@ -16,9 +16,17 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+  push:
+    branches:
+      - main
+
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: generate-factsheets-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   generate:
@@ -91,7 +99,7 @@ jobs:
           if-no-files-found: error
 
       - name: Commit refreshed data back to the branch
-        if: ${{ github.event_name == 'push' && github.event.inputs.skip_commit != 'true' }}
+        if: ${{ github.event_name == 'push' && github.ref_name != 'main' && github.event.inputs.skip_commit != 'true' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -109,7 +117,7 @@ jobs:
           git push origin "HEAD:${GITHUB_REF_NAME}"
 
       - name: Open PR with refreshed data
-        if: ${{ github.event_name != 'push' && github.event.inputs.skip_commit != 'true' }}
+        if: ${{ (github.event_name != 'push' || github.ref_name == 'main') && github.event.inputs.skip_commit != 'true' }}
         uses: peter-evans/create-pull-request@v6
         with:
           base: main


### PR DESCRIPTION
## Summary
Updated the factsheet generation workflow to trigger on pushes to the main branch and prevent committing changes back to main, instead opening a PR for review.

## Key Changes
- Added `push` trigger for the main branch to the workflow schedule
- Added concurrency configuration to cancel in-progress runs for the same ref
- Modified the "Commit refreshed data" step to skip execution when pushing to main (`github.ref_name != 'main'`)
- Modified the "Open PR with refreshed data" step to create a PR when either:
  - The event is not a push, OR
  - The event is a push to main

## Implementation Details
These changes ensure that:
1. The workflow runs automatically when code is pushed to main
2. Generated/refreshed data is never committed directly back to main
3. Instead, a pull request is opened for review when main is updated
4. Only in-progress runs for the same branch are cancelled, preventing duplicate executions

https://claude.ai/code/session_019S8EzCdQnr8k1haFus8oCV