### PR TITLE
fix(Common): Restore broken scripts/_common.py docstring on main

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -21,8 +21,7 @@ def get_api_key() -> str:
 
 def drop_incomplete_last_day(returns: pd.Series) -> pd.Series:
     """Drop a trailing same-day (incomplete) observation so the series ends on
-    the last *complete* UTC day.
-
+    the last *complete* UTC day."""
     import pandas as pd
 
     if returns.empty:


### PR DESCRIPTION
## ⚠️ `main` is currently broken — this restores it

A review-suggestion commit merged in #36 trimmed the `drop_incomplete_last_day` docstring in `scripts/_common.py` but **removed its closing `"""`** along with the paragraph. That left the string open all the way down to `job_count`'s docstring, so the em-dash there is parsed as *code*:

```
  File "scripts/_common.py", line 73
    default — the work is dominated by Unravel API round-trips."""
            ^
SyntaxError: invalid character '—' (U+2014)
```

Every entry point that imports `scripts._common` (`export_data`, `export_portfolio_returns`, `generate_factsheets`, `generate_portfolio_factsheets`) fails to start — i.e. the whole factsheet/CSV refresh pipeline is down on `main`.

## Fix
One line: restore the closing `"""` (keeping the reviewer's shorter two-line docstring). `python -m compileall scripts/` is clean again.

The identical break exists on the open factors-dataroom PR #20 and has been fixed there too (`scripts/_common.py`).

Please merge promptly to unblock the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyFz7D8u8cEfmw6w9pDzqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyFz7D8u8cEfmw6w9pDzqa)_