### PR TITLE
fix(Table): Fix layout and metrics display in factsheet page one

### DIFF
--- a/scripts/factsheet/page_one.py
+++ b/scripts/factsheet/page_one.py
@@ -309,12 +309,16 @@ def _draw_section_eyebrow(
     right_label: str = "",
     sub_label: str = "",
     sub_label_wrap: int = 140,
-) -> None:
+) -> float:
     """Section divider. Title left + optional caption right + thin rule above.
 
     When ``sub_label`` is set it sits underneath the title as a muted
     line, wrapped at ``sub_label_wrap`` chars (narrow it when a right-side
-    control shares the header row so the text stays clear of it)."""
+    control shares the header row so the text stays clear of it).
+
+    Returns the figure-fraction y of the caption's bottom edge so the caller
+    can flow the next band beneath a caption that wraps to a variable number
+    of lines; with no ``sub_label`` this is just ``y``."""
     _hline(fig, y + 0.013, lw=0.6)
     fig.text(
         MARGIN_X,
@@ -335,18 +339,22 @@ def _draw_section_eyebrow(
             va="top",
             ha="right",
         )
-    if sub_label:
-        # Wrap to the full text column so the sub-label never spills past
-        # the right margin even on factors with long universe descriptions.
-        fig.text(
-            MARGIN_X,
-            y - 0.013,
-            _wrap(sub_label, width=sub_label_wrap),
-            fontsize=7.5,
-            color=theme.MUTED,
-            va="top",
-            linespacing=1.4,
-        )
+    if not sub_label:
+        return y
+    # Wrap to the full text column so the sub-label never spills past
+    # the right margin even on factors with long universe descriptions.
+    sub_top = y - 0.013
+    st = fig.text(
+        MARGIN_X,
+        sub_top,
+        _wrap(sub_label, width=sub_label_wrap),
+        fontsize=7.5,
+        color=theme.MUTED,
+        va="top",
+        linespacing=1.4,
+    )
+    _, h_frac = _text_extent_frac(fig, st)
+    return sub_top - h_frac
 
 
 # ---------- tabular performance / risk bands ---------------------------------
@@ -455,6 +463,10 @@ def _draw_performance_band(
     )
     cum = metrics.cumulative_returns_by_window(returns)
     cagr = metrics.cagr_by_window(returns)
+    # 1M / 3M sit with the cumulative figures as compound (not annualised)
+    # returns — extrapolating a sub-quarter window to a yearly rate overstates
+    # it. gross_return_by_window gives the trailing compound return per window.
+    gross = metrics.gross_return_by_window(returns)
     _draw_table_band(
         fig,
         y_top,
@@ -464,6 +476,8 @@ def _draw_performance_band(
                 "cols": [
                     ("MTD", metrics.fmt_pct(cum["MTD"])),
                     ("Last Month", metrics.fmt_pct(cum["LastMonth"])),
+                    ("1M", metrics.fmt_pct(gross["1M"])),
+                    ("3M", metrics.fmt_pct(gross["3M"])),
                     ("YTD", metrics.fmt_pct(cum["YTD"])),
                     ("1Y", metrics.fmt_pct(cum["1Y"])),
                 ],
@@ -472,7 +486,7 @@ def _draw_performance_band(
                 "title": "Annualised Returns (CAGR)",
                 "cols": [
                     (lbl, metrics.fmt_pct(cagr[lbl]))
-                    for lbl in ("1M", "3M", "1Y", "3Y", "5Y", "SI")
+                    for lbl in ("1Y", "3Y", "5Y", "SI")
                 ],
             },
         ],
@@ -677,7 +691,7 @@ def render_page_one(
     _draw_overview(fig, factor, y_top=overview_top)
 
     section_label, section_sub_label = _section_copy(factor)
-    _draw_section_eyebrow(
+    eyebrow_bottom = _draw_section_eyebrow(
         fig,
         y=0.520,
         label=section_label,
@@ -702,8 +716,12 @@ def render_page_one(
         fontsize=7,
     )
 
-    # Performance + risk tabular bands (replace the heatmap & KPI strip)
-    _draw_performance_band(fig, returns, stats, y_top=0.453)
+    # Performance + risk tabular bands (replace the heatmap & KPI strip).
+    # A long (3-line) caption would otherwise overlap the PERFORMANCE header,
+    # so drop the band just enough to clear the caption's measured bottom;
+    # short captions keep the tuned 0.453 position (the clamp is a no-op).
+    perf_y_top = min(0.453, eyebrow_bottom - 0.028)
+    _draw_performance_band(fig, returns, stats, y_top=perf_y_top)
     _draw_risk_band(fig, returns, stats, y_top=0.363)
 
     # Cumulative return — full width below the tables

--- a/scripts/factsheet/page_one.py
+++ b/scripts/factsheet/page_one.py
@@ -442,7 +442,7 @@ def _draw_performance_band(
     fig: plt.Figure, returns: pd.Series, stats: metrics.Stats, y_top: float
 ) -> None:
     """Two-group Performance band: Cumulative Returns
-    (MTD / Last Month / 1M / 3M / YTD / 1Y) on the left, annualised CAGR
+    (MTD / Last Month / 1M / 3M / YTD) on the left, annualised CAGR
     (1Y / 3Y / 5Y / SI) on the right. Mirrors the PerformanceSummaryTable
     on the site's portfolio page."""
     fig.text(
@@ -479,7 +479,6 @@ def _draw_performance_band(
                     ("1M", metrics.fmt_pct(gross["1M"])),
                     ("3M", metrics.fmt_pct(gross["3M"])),
                     ("YTD", metrics.fmt_pct(cum["YTD"])),
-                    ("1Y", metrics.fmt_pct(cum["1Y"])),
                 ],
             },
             {

--- a/scripts/factsheet/page_one.py
+++ b/scripts/factsheet/page_one.py
@@ -441,10 +441,10 @@ def _draw_table_band(
 def _draw_performance_band(
     fig: plt.Figure, returns: pd.Series, stats: metrics.Stats, y_top: float
 ) -> None:
-    """Two-group Performance band: calendar-anchored Cumulative Returns
-    (MTD / Last Month / YTD / 1Y) on the left, trailing CAGR
-    (1M / 3M / 1Y / 3Y / 5Y / SI) on the right. Mirrors the
-    PerformanceSummaryTable on the site's portfolio page."""
+    """Two-group Performance band: Cumulative Returns
+    (MTD / Last Month / 1M / 3M / YTD / 1Y) on the left, annualised CAGR
+    (1Y / 3Y / 5Y / SI) on the right. Mirrors the PerformanceSummaryTable
+    on the site's portfolio page."""
     fig.text(
         MARGIN_X, y_top + 0.022, "PERFORMANCE",
         fontsize=7, color=theme.MUTED, weight="semibold", va="top",


### PR DESCRIPTION
## Summary
This PR fixes layout positioning and updates performance metrics display in the factsheet page one rendering. The changes ensure proper spacing when section captions wrap to multiple lines and corrects which return metrics are displayed in the performance band.

## Key Changes

- **Return type and layout handling**: Modified `_draw_section_eyebrow()` to return the bottom y-position of the caption (accounting for text wrapping), allowing callers to properly position subsequent content below variable-height captions.

- **Dynamic performance band positioning**: Updated `render_page_one()` to use the measured caption height to dynamically position the performance band, preventing overlap when captions wrap to multiple lines while maintaining the tuned position for short captions.

- **Performance metrics correction**: 
  - Added `gross_return_by_window()` calculation to get trailing compound returns for 1M and 3M periods
  - Moved 1M and 3M metrics from the "Annualised Returns (CAGR)" section to the cumulative returns section, since these short windows should not be annualized
  - Removed 1M and 3M from CAGR display, keeping only 1Y, 3Y, 5Y, and SI periods

- **Documentation**: Enhanced docstring for `_draw_section_eyebrow()` to explain the return value and its purpose for layout flow control.

## Implementation Details

The layout fix uses `_text_extent_frac()` to measure the actual rendered height of wrapped sub-labels, then clamps the performance band position to ensure it doesn't overlap with longer captions while preserving the original tuned spacing for typical cases.

https://claude.ai/code/session_016v4a7cG2B8ZbBGdKJxCyUt