### PR TITLE
chore(CI): Auto-merge scheduled notebook refresh PRs

### DIFF
--- a/.github/workflows/generate-notebooks.yml
+++ b/.github/workflows/generate-notebooks.yml
@@ -102,6 +102,7 @@ jobs:
           git push origin "HEAD:${GITHUB_REF_NAME}"
 
       - name: Open PR with refreshed notebooks
+        id: cpr
         if: ${{ success() && (github.event_name != 'push' || github.ref_name == 'main') }}
         uses: peter-evans/create-pull-request@v6
         with:
@@ -120,4 +121,16 @@ jobs:
             outputs match the substituted parameters.
 
             Trigger: `${{ github.event_name }}`.
+
+            Scheduled runs auto-merge once branch-protection requirements are
+            met; for manual / `main` triggers, review the diff and merge.
           delete-branch: true
+
+      - name: Auto-merge the scheduled refresh
+        if: ${{ github.event_name == 'schedule' && steps.cpr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh pr merge "$PR" --squash --delete-branch --auto \
+            || gh pr merge "$PR" --squash --delete-branch


### PR DESCRIPTION
## Summary
This change adds automatic merging of pull requests created by scheduled notebook refresh runs, while keeping manual and main-branch triggers requiring manual review.

## Key Changes
- Added `id: cpr` to the "Open PR with refreshed notebooks" step to capture pull request outputs
- Updated PR description to clarify merge behavior: scheduled runs auto-merge once branch protection requirements are met, while manual/main triggers require manual review
- Added new "Auto-merge the scheduled refresh" step that:
  - Only runs on scheduled events when a PR is successfully created
  - Uses `gh pr merge` with `--auto` flag to merge once all branch protection checks pass
  - Falls back to immediate merge if auto-merge is not available
  - Uses squash merge strategy and deletes the branch after merge

## Implementation Details
The auto-merge step leverages GitHub's `--auto` flag which respects branch protection rules and only merges when all required checks pass. The fallback ensures compatibility if auto-merge is unavailable in the environment.

https://claude.ai/code/session_01FPVibqkHeEr8b21WHjQqKB